### PR TITLE
fix(jsonata): lower default maxDepth to prevent Windows worker crash

### DIFF
--- a/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/JSONataInterface.java
+++ b/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/JSONataInterface.java
@@ -12,7 +12,10 @@ public interface JSONataInterface {
     @PluginProperty(group = "main")
     Property<String> getExpression();
 
-    @Schema(title = "The maximum number of recursive calls allowed for the JSONata transformation.")
+    @Schema(
+        title = "The maximum number of recursive calls allowed for the JSONata transformation.",
+        description = "Limits recursive JSONata function call depth. Each recursive call adds a frame to the chain traversed by variable lookup, so high values can cause a JVM StackOverflowError on platforms with small default thread stacks (e.g. Windows ~256 KB vs Linux ~512 KB). Raise only for expressions with proven deep recursion needs."
+    )
     @NotNull
     @PluginProperty(group = "main")
     Property<Integer> getMaxDepth();

--- a/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
+++ b/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
@@ -37,15 +37,18 @@ public abstract class Transform<T extends Output> extends Task implements JSONat
     private Property<String> expression;
 
     @Builder.Default
-    private Property<Integer> maxDepth = Property.ofValue(1000);
+    private Property<Integer> maxDepth = Property.ofValue(200);
 
-    @Getter(AccessLevel.PRIVATE)
+    @Getter(AccessLevel.NONE)
+    private String parsedExpressionSource;
+
+    @Getter(AccessLevel.NONE)
     private Jsonata parsedExpression;
 
     public void init(RunContext runContext) throws Exception {
-        var exprString = runContext.render(this.expression).as(String.class).orElseThrow();
+        this.parsedExpressionSource = runContext.render(this.expression).as(String.class).orElseThrow();
         try {
-            this.parsedExpression = jsonata(exprString);
+            this.parsedExpression = jsonata(this.parsedExpressionSource);
         } catch (JException e) {
             throw new IllegalArgumentException("Invalid JSONata expression. Error: " + e.getMessage(), e);
         }
@@ -69,6 +72,15 @@ public abstract class Transform<T extends Output> extends Task implements JSONat
             return MAPPER.valueToTree(result);
         } catch (JException | IllegalVariableEvaluationException e) {
             throw new RuntimeException("Failed to evaluate expression", e);
+        } catch (StackOverflowError e) {
+            // Jsonata instance has mutable fields (errors, environment) that may be in a partial state
+            // after overflow. Re-parse to get a clean instance so subsequent evaluations are unaffected.
+            try {
+                this.parsedExpression = jsonata(this.parsedExpressionSource);
+            } catch (JException ignored) {
+                // expression was valid before; ignore re-parse failure
+            }
+            throw new RuntimeException("JSONata expression exceeded JVM stack depth — reduce expression complexity or lower maxDepth", e);
         }
     }
 }

--- a/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
+++ b/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
@@ -39,16 +39,13 @@ public abstract class Transform<T extends Output> extends Task implements JSONat
     @Builder.Default
     private Property<Integer> maxDepth = Property.ofValue(200);
 
-    @Getter(AccessLevel.NONE)
-    private String parsedExpressionSource;
-
-    @Getter(AccessLevel.NONE)
+    @Getter(AccessLevel.PRIVATE)
     private Jsonata parsedExpression;
 
     public void init(RunContext runContext) throws Exception {
-        this.parsedExpressionSource = runContext.render(this.expression).as(String.class).orElseThrow();
+        var exprString = runContext.render(this.expression).as(String.class).orElseThrow();
         try {
-            this.parsedExpression = jsonata(this.parsedExpressionSource);
+            this.parsedExpression = jsonata(exprString);
         } catch (JException e) {
             throw new IllegalArgumentException("Invalid JSONata expression. Error: " + e.getMessage(), e);
         }
@@ -72,15 +69,6 @@ public abstract class Transform<T extends Output> extends Task implements JSONat
             return MAPPER.valueToTree(result);
         } catch (JException | IllegalVariableEvaluationException e) {
             throw new RuntimeException("Failed to evaluate expression", e);
-        } catch (StackOverflowError e) {
-            // Jsonata instance has mutable fields (errors, environment) that may be in a partial state
-            // after overflow. Re-parse to get a clean instance so subsequent evaluations are unaffected.
-            try {
-                this.parsedExpression = jsonata(this.parsedExpressionSource);
-            } catch (JException ignored) {
-                // expression was valid before; ignore re-parse failure
-            }
-            throw new RuntimeException("JSONata expression exceeded JVM stack depth — reduce expression complexity or lower maxDepth", e);
         }
     }
 }


### PR DESCRIPTION
Fixes [Pylon #1703](https://app.usepylon.com/support/issues/views/36469f3c-64a7-47dc-8e82-9d36026bfc31?issueNumber=1703&view=fs)

## Root cause

`Jsonata$Frame.lookup()` traverses the frame parent chain recursively. With the old default `maxDepth=1000`, a recursive JSONata function can build a 1000-deep frame chain, causing `lookup()` to recurse 1000 levels. The Windows JVM default thread stack (~256 KB) overflows well before Linux (~512 KB) does. Reactor's `throwIfFatal` treats `StackOverflowError` as a JVM fatal, re-throws it, and `ThreadUncaughtExceptionHandler` shuts down the entire worker process.

## What changed

**1. Lower default `maxDepth` from 1000 → 200** — makes JSONata's own `JException` depth guard fire before the JVM stack overflows on Windows. Users who genuinely need deeper recursion can raise it explicitly in their flow YAML.

**2. Improve `maxDepth` schema description** — documents the platform-specific stack size difference and the trade-off of raising the value.

## Breaking change

Flows using deeply recursive JSONata expressions (depth > 200) will now fail with `JException` instead of working. Those users must add `maxDepth: <N>` to their task. This is intentional — expressions that previously crashed Windows workers will now fail gracefully on all platforms.

## Immediate workaround (before deploying this fix)

Add `maxDepth: 100` to affected tasks in the flow YAML. This makes JSONata's depth guard fire before the JVM stack overflows.

## Test plan

- [ ] `TransformValueTest` and `TransformItemsTest` pass
- [ ] Deploy to a Windows worker — flows run correctly, recursive expressions fail with clear error instead of crashing the service
- [ ] Verify `maxDepth` can be raised in flow YAML for legitimate deep-recursion use cases