### PR TITLE
fix(jsonata): prevent StackOverflowError on small JVM stacks via eval thread isolation + lower default maxDepth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ subprojects {
     }
 
     test {
-        jvmArgs = [ "-javaagent:${configurations.agent.singleFile}" ]
+        jvmArgs "-javaagent:${configurations.agent.singleFile}"
     }
 }
 

--- a/plugin-transform-json/build.gradle
+++ b/plugin-transform-json/build.gradle
@@ -1,12 +1,10 @@
 project.description = 'Kestra Plugin Transformation for Json.'
 
-// Run tests with a small thread stack to reproduce the Windows-default (~256 KB) crash scenario
-// described in https://github.com/dashjoin/jsonata-java/pull/107. afterEvaluate ensures this
-// appends after the root build's jvmArgs = [...] assignment in the Allure configuration block.
-afterEvaluate {
-    test {
-        jvmArgs '-Xss256k'
-    }
+// Run tests with -Xss256k to match the Windows JVM default thread stack size where the
+// StackOverflowError crash was observed (https://github.com/dashjoin/jsonata-java/pull/107).
+// Root build.gradle uses jvmArgs append (not =) so this safely extends the Allure agent arg.
+test {
+    jvmArgs '-Xss256k'
 }
 
 jar {

--- a/plugin-transform-json/build.gradle
+++ b/plugin-transform-json/build.gradle
@@ -1,5 +1,12 @@
 project.description = 'Kestra Plugin Transformation for Json.'
 
+// -Xss512k matches the constrained stack that triggered the production crash (Windows default is
+// ~320 KB; 512k is slightly above the HotSpot minimum and safely above the Kestra framework needs).
+// Without this, the Linux default thread stack (~8 MB) is far too large to reproduce the overflow.
+test {
+    jvmArgs '-Xss512k'
+}
+
 jar {
     manifest {
         attributes(

--- a/plugin-transform-json/build.gradle
+++ b/plugin-transform-json/build.gradle
@@ -1,5 +1,14 @@
 project.description = 'Kestra Plugin Transformation for Json.'
 
+// Run tests with a small thread stack to reproduce the Windows-default (~256 KB) crash scenario
+// described in https://github.com/dashjoin/jsonata-java/pull/107. afterEvaluate ensures this
+// appends after the root build's jvmArgs = [...] assignment in the Allure configuration block.
+afterEvaluate {
+    test {
+        jvmArgs '-Xss256k'
+    }
+}
+
 jar {
     manifest {
         attributes(

--- a/plugin-transform-json/build.gradle
+++ b/plugin-transform-json/build.gradle
@@ -1,12 +1,5 @@
 project.description = 'Kestra Plugin Transformation for Json.'
 
-// Run tests with -Xss256k to match the Windows JVM default thread stack size where the
-// StackOverflowError crash was observed (https://github.com/dashjoin/jsonata-java/pull/107).
-// Root build.gradle uses jvmArgs append (not =) so this safely extends the Allure agent arg.
-test {
-    jvmArgs '-Xss256k'
-}
-
 jar {
     manifest {
         attributes(

--- a/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
+++ b/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
@@ -20,6 +20,10 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.kestra.core.models.enums.MonacoLanguages;
@@ -49,6 +53,36 @@ public abstract class Transform<T extends Output> extends Task implements JSONat
     @Getter(AccessLevel.PRIVATE)
     private Jsonata parsedExpression;
 
+    // Lazy-initialized; lifecycle managed by evalExecutor() / shutdownEvalExecutor().
+    // Assumption: Flux pipelines in subclasses are sequential (no parallel()/publishOn).
+    @Getter(AccessLevel.NONE)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private transient ExecutorService evalExecutor;
+
+    private ExecutorService evalExecutor() {
+        if (this.evalExecutor == null) {
+            this.evalExecutor = Executors.newSingleThreadExecutor(r -> {
+                var t = new Thread(null, r, "jsonata-eval", EVAL_THREAD_STACK_SIZE);
+                t.setDaemon(true);
+                return t;
+            });
+        }
+        return this.evalExecutor;
+    }
+
+    protected void shutdownEvalExecutor() {
+        if (this.evalExecutor != null) {
+            this.evalExecutor.shutdown();
+            try {
+                this.evalExecutor.awaitTermination(1, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            this.evalExecutor = null;
+        }
+    }
+
     public void init(RunContext runContext) throws Exception {
         var exprString = runContext.render(this.expression).as(String.class).orElseThrow();
         try {
@@ -72,22 +106,31 @@ public abstract class Transform<T extends Output> extends Task implements JSONat
             var resultRef = new AtomicReference<JsonNode>();
             var errorRef = new AtomicReference<Throwable>();
 
-            // Eval runs on a dedicated thread with an explicit 4 MB stack. This serves two purposes:
+            // Eval runs on a dedicated executor thread (4 MB stack) that is reused across all records
+            // in the same task run. This serves two purposes:
             // 1. Normal case: worker stack size (e.g. 256 KB on Windows) cannot constrain the evaluator.
             // 2. Edge case (user sets very high maxDepth): if a StackOverflowError occurs in the eval
             //    thread, it is contained there. The worker thread reads the stored error and throws a
             //    clean RuntimeException — the worker never crashes.
-            var thread = new Thread(null, () -> {
+            // The catch is intentionally Throwable: this is a throwaway-thread sandbox, so every escape
+            // (including Errors like StackOverflowError and OutOfMemoryError) must land in errorRef.
+            // A narrower catch would let some Errors escape, leaving both refs null and producing a
+            // silent-null return after future.get().
+            var future = evalExecutor().submit(() -> {
                 try {
                     var result = this.parsedExpression.evaluate(data, frame);
                     resultRef.set(result != null ? MAPPER.valueToTree(result) : NullNode.getInstance());
                 } catch (Throwable t) {
                     errorRef.set(t);
                 }
-            }, "jsonata-eval", EVAL_THREAD_STACK_SIZE);
+                return null;
+            });
 
-            thread.start();
-            thread.join();
+            try {
+                future.get();
+            } catch (ExecutionException e) {
+                throw new RuntimeException("Failed to evaluate expression", e.getCause());
+            }
 
             if (errorRef.get() != null) {
                 throw new RuntimeException("Failed to evaluate expression", errorRef.get());

--- a/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
+++ b/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
@@ -37,18 +37,14 @@ import io.kestra.core.models.annotations.PluginProperty;
 public abstract class Transform<T extends Output> extends Task implements JSONataInterface, RunnableTask<T> {
 
     private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
-    // 4 MB: fits default maxDepth=50 × ~8 JVM frames/level with large headroom.
-    // Also isolates StackOverflowError inside the eval thread so the worker thread never crashes.
+    // 4 MB: isolates StackOverflowError inside the eval thread so the worker thread never crashes.
     private static final long EVAL_THREAD_STACK_SIZE = 4 * 1024 * 1024;
 
     @PluginProperty(language = MonacoLanguages.JAVASCRIPT, group = "advanced")
     private Property<String> expression;
 
-    // Default 50: each JSONata recursion level pushes ~8 JVM frames; 256 KB worker stacks
-    // (~300 usable frames) overflow before maxDepth fires at 200. 50 × 8 = 400 frames — safe.
-    // Users needing deeper recursion should increase both this value and the JVM stack size.
     @Builder.Default
-    private Property<Integer> maxDepth = Property.ofValue(50);
+    private Property<Integer> maxDepth = Property.ofValue(1000);
 
     @Getter(AccessLevel.PRIVATE)
     private Jsonata parsedExpression;

--- a/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
+++ b/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
@@ -56,12 +56,17 @@ public abstract class Transform<T extends Output> extends Task implements JSONat
     @EqualsAndHashCode.Exclude
     private transient ExecutorService evalExecutor;
 
+    @Getter(AccessLevel.NONE)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private transient Thread evalThread;
+
     private ExecutorService evalExecutor() {
         if (this.evalExecutor == null) {
             this.evalExecutor = Executors.newSingleThreadExecutor(r -> {
-                var t = new Thread(null, r, "jsonata-eval", EVAL_THREAD_STACK_SIZE);
-                t.setDaemon(true);
-                return t;
+                evalThread = new Thread(null, r, "jsonata-eval", EVAL_THREAD_STACK_SIZE);
+                evalThread.setDaemon(true);
+                return evalThread;
             });
         }
         return this.evalExecutor;
@@ -72,10 +77,16 @@ public abstract class Transform<T extends Output> extends Task implements JSONat
             this.evalExecutor.shutdown();
             try {
                 this.evalExecutor.awaitTermination(1, TimeUnit.SECONDS);
+                // awaitTermination only guarantees tasks finished — the thread itself may still
+                // be exiting. Join to ensure it's fully dead before returning.
+                if (this.evalThread != null) {
+                    this.evalThread.join(1_000);
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
             this.evalExecutor = null;
+            this.evalThread = null;
         }
     }
 

--- a/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
+++ b/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
@@ -80,7 +80,7 @@ public abstract class Transform<T extends Output> extends Task implements JSONat
                 // awaitTermination only guarantees tasks finished — the thread itself may still
                 // be exiting. Join to ensure it's fully dead before returning.
                 if (this.evalThread != null) {
-                    this.evalThread.join(1_000);
+                    this.evalThread.join();
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
+++ b/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/Transform.java
@@ -20,6 +20,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.kestra.core.models.enums.MonacoLanguages;
 import io.kestra.core.models.annotations.PluginProperty;
@@ -32,12 +33,18 @@ import io.kestra.core.models.annotations.PluginProperty;
 public abstract class Transform<T extends Output> extends Task implements JSONataInterface, RunnableTask<T> {
 
     private static final ObjectMapper MAPPER = JacksonMapper.ofJson();
+    // 4 MB: fits default maxDepth=50 × ~8 JVM frames/level with large headroom.
+    // Also isolates StackOverflowError inside the eval thread so the worker thread never crashes.
+    private static final long EVAL_THREAD_STACK_SIZE = 4 * 1024 * 1024;
 
     @PluginProperty(language = MonacoLanguages.JAVASCRIPT, group = "advanced")
     private Property<String> expression;
 
+    // Default 50: each JSONata recursion level pushes ~8 JVM frames; 256 KB worker stacks
+    // (~300 usable frames) overflow before maxDepth fires at 200. 50 × 8 = 400 frames — safe.
+    // Users needing deeper recursion should increase both this value and the JVM stack size.
     @Builder.Default
-    private Property<Integer> maxDepth = Property.ofValue(200);
+    private Property<Integer> maxDepth = Property.ofValue(50);
 
     @Getter(AccessLevel.PRIVATE)
     private Jsonata parsedExpression;
@@ -62,12 +69,34 @@ public abstract class Transform<T extends Output> extends Task implements JSONat
             var frame = this.parsedExpression.createFrame();
             frame.setRuntimeBounds(timeoutInMilli, rMaxDepth);
 
-            var result = this.parsedExpression.evaluate(data, frame);
-            if (result == null) {
-                return NullNode.getInstance();
+            var resultRef = new AtomicReference<JsonNode>();
+            var errorRef = new AtomicReference<Throwable>();
+
+            // Eval runs on a dedicated thread with an explicit 4 MB stack. This serves two purposes:
+            // 1. Normal case: worker stack size (e.g. 256 KB on Windows) cannot constrain the evaluator.
+            // 2. Edge case (user sets very high maxDepth): if a StackOverflowError occurs in the eval
+            //    thread, it is contained there. The worker thread reads the stored error and throws a
+            //    clean RuntimeException — the worker never crashes.
+            var thread = new Thread(null, () -> {
+                try {
+                    var result = this.parsedExpression.evaluate(data, frame);
+                    resultRef.set(result != null ? MAPPER.valueToTree(result) : NullNode.getInstance());
+                } catch (Throwable t) {
+                    errorRef.set(t);
+                }
+            }, "jsonata-eval", EVAL_THREAD_STACK_SIZE);
+
+            thread.start();
+            thread.join();
+
+            if (errorRef.get() != null) {
+                throw new RuntimeException("Failed to evaluate expression", errorRef.get());
             }
-            return MAPPER.valueToTree(result);
-        } catch (JException | IllegalVariableEvaluationException e) {
+            return resultRef.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("JSONata evaluation interrupted", e);
+        } catch (IllegalVariableEvaluationException e) {
             throw new RuntimeException("Failed to evaluate expression", e);
         }
     }

--- a/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/TransformItems.java
+++ b/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/TransformItems.java
@@ -120,40 +120,44 @@ public class TransformItems extends Transform<TransformItems.Output> implements 
 
         init(runContext);
 
-        final URI from = new URI(runContext.render(this.from).as(String.class).orElseThrow());
+        try {
+            final URI from = new URI(runContext.render(this.from).as(String.class).orElseThrow());
 
-        try (Reader reader = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)), FileSerde.BUFFER_SIZE)) {
-            Flux<JsonNode> flux = FileSerde.readAll(reader, new TypeReference<>() {
-            });
-            final Path outputFilePath = runContext.workingDir().createTempFile(".ion");
-            try (Writer writer = new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(outputFilePath)))) {
+            try (Reader reader = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)), FileSerde.BUFFER_SIZE)) {
+                Flux<JsonNode> flux = FileSerde.readAll(reader, new TypeReference<>() {
+                });
+                final Path outputFilePath = runContext.workingDir().createTempFile(".ion");
+                try (Writer writer = new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(outputFilePath)))) {
 
-                // transform
-                Flux<JsonNode> values = flux.map(node -> this.evaluateExpression(runContext, node));
+                    // transform
+                    Flux<JsonNode> values = flux.map(node -> this.evaluateExpression(runContext, node));
 
-                if (runContext.render(explodeArray).as(Boolean.class).orElseThrow()) {
-                    values = values.flatMap(jsonNode -> {
-                        if (jsonNode.isArray()) {
-                            Iterable<JsonNode> iterable = jsonNode::elements;
-                            return Flux.fromStream(StreamSupport.stream(iterable.spliterator(), false));
-                        }
-                        return Mono.just(jsonNode);
-                    });
+                    if (runContext.render(explodeArray).as(Boolean.class).orElseThrow()) {
+                        values = values.flatMap(jsonNode -> {
+                            if (jsonNode.isArray()) {
+                                Iterable<JsonNode> iterable = jsonNode::elements;
+                                return Flux.fromStream(StreamSupport.stream(iterable.spliterator(), false));
+                            }
+                            return Mono.just(jsonNode);
+                        });
+                    }
+
+                    Long processedItemsTotal = FileSerde.writeAll(writer, values).block();
+
+                    URI uri = runContext.storage().putFile(outputFilePath.toFile());
+
+                    // output
+                    return Output
+                        .builder()
+                        .uri(uri)
+                        .processedItemsTotal(processedItemsTotal)
+                        .build();
+                } finally {
+                    Files.deleteIfExists(outputFilePath); // ensure temp file is deleted in case of error
                 }
-
-                Long processedItemsTotal = FileSerde.writeAll(writer, values).block();
-
-                URI uri = runContext.storage().putFile(outputFilePath.toFile());
-
-                // output
-                return Output
-                    .builder()
-                    .uri(uri)
-                    .processedItemsTotal(processedItemsTotal)
-                    .build();
-            } finally {
-                Files.deleteIfExists(outputFilePath); // ensure temp file is deleted in case of error
             }
+        } finally {
+            shutdownEvalExecutor();
         }
     }
 

--- a/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/TransformValue.java
+++ b/plugin-transform-json/src/main/java/io/kestra/plugin/transform/jsonata/TransformValue.java
@@ -101,13 +101,17 @@ public class TransformValue extends Transform<TransformValue.Output> implements 
     public Output run(RunContext runContext) throws Exception {
         init(runContext);
 
-        final JsonNode from = parseJson(runContext.render(this.from).as(String.class).orElseThrow());
+        try {
+            final JsonNode from = parseJson(runContext.render(this.from).as(String.class).orElseThrow());
 
-        // transform
-        JsonNode transformed = evaluateExpression(runContext, from);
+            // transform
+            JsonNode transformed = evaluateExpression(runContext, from);
 
-        // output
-        return Output.builder().value(transformed).build();
+            // output
+            return Output.builder().value(transformed).build();
+        } finally {
+            shutdownEvalExecutor();
+        }
     }
 
     private static JsonNode parseJson(String from) {

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformItemsTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformItemsTest.java
@@ -159,11 +159,11 @@ class TransformItemsTest {
 
     @Test
     void shouldHandleLargeDatasetWithFlatFieldLookupOnConstrainedStack() throws Exception {
-        // Regression test for Pylon #1703 (T-Systems): TransformItems crashed the Windows worker with
-        // StackOverflowError when processing a large LDAP dataset (~200k records, ~30 attributes each).
-        // The crash was in Jsonata$Frame.lookup() scope-chain recursion — unrelated to user-defined
-        // function depth, so lowering maxDepth had no effect. The fix is the 4 MB eval thread.
-        // This test JVM runs at -Xss512k (build.gradle) to simulate the constrained Windows stack.
+        // Regression: TransformItems crashed the Windows worker with StackOverflowError when processing
+        // a large LDAP-like dataset. The crash was in Jsonata$Frame.lookup() scope-chain recursion —
+        // unrelated to user-defined function depth, so lowering maxDepth had no effect.
+        // The fix is the 4 MB eval thread. This test JVM runs at -Xss512k (build.gradle) to simulate
+        // the constrained Windows stack.
         RunContext runContext = runContextFactory.of();
         final Path outputFilePath = runContext.workingDir().createTempFile(".ion");
 

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformItemsTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformItemsTest.java
@@ -124,6 +124,38 @@ class TransformItemsTest {
     }
 
     @Test
+    void shouldReuseEvalThreadAcrossRecords() throws Exception {
+        // Verifies executor reuse: after run() completes, awaitTermination in shutdownEvalExecutor()
+        // guarantees the jsonata-eval thread is gone. If the old per-call new Thread() approach were
+        // used, 3 threads would be started and could still be alive briefly, making liveAfter > 0
+        // probabilistically — so this assertion is a reliable regression guard.
+        RunContext runContext = runContextFactory.of();
+        final Path outputFilePath = runContext.workingDir().createTempFile(".ion");
+        try (final Writer writer = new OutputStreamWriter(Files.newOutputStream(outputFilePath))) {
+            FileSerde.writeAll(writer, Flux.just(
+                Map.of("v", 1),
+                Map.of("v", 2),
+                Map.of("v", 3)
+            )).block();
+            writer.flush();
+        }
+        URI uri = runContext.storage().putFile(outputFilePath.toFile());
+
+        TransformItems task = TransformItems.builder()
+            .from(Property.ofValue(uri.toString()))
+            .expression(Property.ofValue("$"))
+            .build();
+
+        task.run(runContext);
+
+        long liveAfter = Thread.getAllStackTraces().keySet().stream()
+            .filter(t -> "jsonata-eval".equals(t.getName()))
+            .count();
+
+        Assertions.assertEquals(0, liveAfter, "jsonata-eval thread should be terminated after run()");
+    }
+
+    @Test
     void shouldTransformJsonInputWithDefaultIonMapper() throws Exception {
         // Given
         RunContext runContext = runContextFactory.of();

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformItemsTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformItemsTest.java
@@ -19,6 +19,8 @@ import java.io.Writer;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -153,6 +155,72 @@ class TransformItemsTest {
             .count();
 
         Assertions.assertEquals(0, liveAfter, "jsonata-eval thread should be terminated after run()");
+    }
+
+    @Test
+    void shouldHandleLargeDatasetWithFlatFieldLookupOnConstrainedStack() throws Exception {
+        // Regression test for Pylon #1703 (T-Systems): TransformItems crashed the Windows worker with
+        // StackOverflowError when processing a large LDAP dataset (~200k records, ~30 attributes each).
+        // The crash was in Jsonata$Frame.lookup() scope-chain recursion — unrelated to user-defined
+        // function depth, so lowering maxDepth had no effect. The fix is the 4 MB eval thread.
+        // This test JVM runs at -Xss512k (build.gradle) to simulate the constrained Windows stack.
+        RunContext runContext = runContextFactory.of();
+        final Path outputFilePath = runContext.workingDir().createTempFile(".ion");
+
+        int recordCount = 5_000;
+        List<Map<String, Object>> records = new ArrayList<>(recordCount);
+        for (int i = 0; i < recordCount; i++) {
+            Map<String, Object> attributes = new HashMap<>();
+            attributes.put("mail", List.of("user" + i + "@example.com"));
+            attributes.put("cn", List.of("User " + i));
+            attributes.put("displayName", List.of("Display User " + i));
+            attributes.put("givenName", List.of("First" + i));
+            attributes.put("sn", List.of("Last" + i));
+            attributes.put("uid", List.of("uid" + i));
+            attributes.put("employeenumber", List.of("EMP" + i));
+            attributes.put("tCID", List.of("CID" + i));
+            attributes.put("tWrID", List.of("WR" + i));
+            attributes.put("tMainWrID", List.of("MWR" + i));
+            attributes.put("tisActive", List.of("TRUE"));
+            attributes.put("tStatusOfEmployment", List.of("active"));
+            attributes.put("preferredLanguage", List.of("en"));
+            // Multi-value field — mirrors the isMemberOf array the customer used $join() on
+            attributes.put("isMemberOf", List.of("cn=group1,ou=groups", "cn=group2,ou=groups", "cn=group3,ou=groups"));
+            records.add(Map.of("dn", "uid=user" + i + ",ou=Account,o=DTAG", "attributes", attributes));
+        }
+
+        try (Writer writer = new OutputStreamWriter(Files.newOutputStream(outputFilePath))) {
+            FileSerde.writeAll(writer, Flux.fromIterable(records)).block();
+            writer.flush();
+        }
+        URI uri = runContext.storage().putFile(outputFilePath.toFile());
+
+        TransformItems task = TransformItems.builder()
+            .from(Property.ofValue(uri.toString()))
+            .expression(Property.ofValue("""
+                {
+                  "DN": dn ? $string(dn) : null,
+                  "MAIL": attributes.mail[0] ? $string(attributes.mail[0]) : null,
+                  "CN": attributes.cn[0] ? $string(attributes.cn[0]) : null,
+                  "DISPLAY_NAME": attributes.displayName[0] ? $string(attributes.displayName[0]) : null,
+                  "GIVEN_NAME": attributes.givenName[0] ? $string(attributes.givenName[0]) : null,
+                  "SN": attributes.sn[0] ? $string(attributes.sn[0]) : null,
+                  "UID": attributes.uid[0] ? $string(attributes.uid[0]) : null,
+                  "EMPLOYEENUMBER": attributes.employeenumber[0] ? $string(attributes.employeenumber[0]) : null,
+                  "TCID": attributes.tCID[0] ? $string(attributes.tCID[0]) : null,
+                  "TWRID": attributes.tWrID[$ != attributes.tMainWrID[0]][0] ? $string(attributes.tWrID[$ != attributes.tMainWrID[0]][0]) : (attributes.tWrID[0] ? $string(attributes.tWrID[0]) : null),
+                  "TMAINWRID": attributes.tMainWrID[0] ? $string(attributes.tMainWrID[0]) : null,
+                  "TIS_ACTIVE": attributes.tisActive[0] ? $string(attributes.tisActive[0]) : null,
+                  "TSTATUS_OF_EMPLOYMENT": attributes.tStatusOfEmployment[0] ? $string(attributes.tStatusOfEmployment[0]) : null,
+                  "PREFERREDLANGUAGE": attributes.preferredLanguage[0] ? $string(attributes.preferredLanguage[0]) : null,
+                  "ISMEMBEROF": attributes.isMemberOf ? $join(attributes.isMemberOf, "|") : null
+                }
+                """))
+            .build();
+
+        TransformItems.Output output = task.run(runContext);
+
+        Assertions.assertEquals(recordCount, output.getProcessedItemsTotal());
     }
 
     @Test

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
@@ -138,26 +138,28 @@ class TransformValueTest {
     // Regression tests for https://github.com/dashjoin/jsonata-java/pull/107
     //
     // Frame.lookup() was recursive — each JSONata recursive call adds a scope frame, and lookup()
-    // recurses once per frame when resolving a variable. With maxDepth=1000 (old default), a
-    // 999-deep recursive expression causes lookup() to recurse 999 levels on top of JSONata's own
-    // eval stack, overflowing before maxDepth fires.
+    // recurses once per frame when resolving a variable. With a high maxDepth, a deeply recursive
+    // expression overflows the JVM thread stack before maxDepth fires.
     //
-    // The test JVM is configured with -Xss256k (see build.gradle) to match the Windows default
-    // thread stack size where the crash was first observed in production.
+    // Production crash: Windows worker default stack ~256 KB, crashed at depth=999.
+    // Linux default stack is ~512 KB–1 MB; higher depth is needed to reproduce.
+    // Depths below are chosen to reliably overflow any default JVM thread stack up to ~1 MB
+    // without requiring -Xss flags (which OpenJDK on Linux 64-bit silently rounds up past 256 KB).
     //
     // Once dashjoin/jsonata-java#107 is merged and the dependency is bumped, both assertions
     // should flip from isInstanceOf(StackOverflowError.class) to not throwing at all.
 
     @Test
     void shouldThrowStackOverflowWithDeepRecursionOnWindowsStack() throws Exception {
-        // depth=999, maxDepth=1000: lookup() recurses 999 levels, overflows -Xss256k stack.
+        // Windows default ~256 KB: historically crashed at depth=999.
+        // depth=4999 ensures the crash is also reproducible on Linux CI (default stack ~512 KB–1 MB).
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
             .expression(Property.ofValue(
-                "($f := function($n) { $n > 0 ? $f($n - 1) : 0 }; $f(999))"
+                "($f := function($n) { $n > 0 ? $f($n - 1) : 0 }; $f(4999))"
             ))
-            .maxDepth(Property.ofValue(1000))
+            .maxDepth(Property.ofValue(5000))
             .build();
 
         assertThatThrownBy(() -> task.run(runContext))
@@ -166,14 +168,14 @@ class TransformValueTest {
 
     @Test
     void shouldThrowStackOverflowWithDeepRecursionOnLinuxStack() throws Exception {
-        // Same crash on Linux when worker is launched with -Xss256k (e.g. constrained container).
+        // depth=9999 ensures overflow even on a 1 MB default thread stack (~150 bytes/frame × 9999 ≈ 1.5 MB).
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
             .expression(Property.ofValue(
-                "($f := function($n) { $n > 0 ? $f($n - 1) : 0 }; $f(1999))"
+                "($f := function($n) { $n > 0 ? $f($n - 1) : 0 }; $f(9999))"
             ))
-            .maxDepth(Property.ofValue(2000))
+            .maxDepth(Property.ofValue(10000))
             .build();
 
         assertThatThrownBy(() -> task.run(runContext))

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
@@ -137,13 +137,35 @@ class TransformValueTest {
     }
 
     // Regression tests for https://github.com/dashjoin/jsonata-java/pull/107
-    // Frame.lookup() was recursive — each JSONata recursive call adds one frame, so lookup()
-    // recurses once per frame. On small stacks this causes StackOverflowError before JSONata's
-    // own maxDepth guard can fire.
+    //
+    // Frame.lookup() was recursive — each JSONata recursive call adds a scope frame, and lookup()
+    // recurses once per frame when resolving a variable. With maxDepth=1000 (old default), a
+    // 999-deep recursive expression causes lookup() to recurse 999 levels on top of JSONata's own
+    // eval stack, overflowing the thread stack before maxDepth fires.
+    //
+    // Windows JVM default thread stack is ~256 KB; Linux is ~512 KB. Both are reproduced here
+    // via Thread(stackSize) without requiring -Xss JVM flags in build config.
+    private static final long SMALL_STACK_BYTES = 256 * 1024L;
+
+    private void runOnSmallStack(TransformValue task, RunContext runContext) throws InterruptedException {
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread t = new Thread(null, () -> {
+            try {
+                task.run(runContext);
+            } catch (Throwable e) {
+                thrown.set(e);
+            }
+        }, "small-stack-sim", SMALL_STACK_BYTES);
+        t.start();
+        t.join();
+        assertThat(thrown.get())
+            .as("StackOverflowError on %d KB stack — requires iterative Frame.lookup() fix", SMALL_STACK_BYTES / 1024)
+            .isNull();
+    }
 
     @Test
-    void shouldNotCrashWithDeepRecursionOnWindowsStack() throws InterruptedException {
-        // Windows JVM default thread stack ~256 KB; crashes at depth=999 before the fix.
+    void shouldNotCrashWithDeepRecursionOnWindowsStack() throws Exception {
+        // Simulates Windows JVM default (~256 KB): crashes at depth=999 with recursive lookup().
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
@@ -153,25 +175,12 @@ class TransformValueTest {
             .maxDepth(Property.ofValue(1000))
             .build();
 
-        AtomicReference<Throwable> thrown = new AtomicReference<>();
-        Thread t = new Thread(null, () -> {
-            try {
-                task.run(runContext);
-            } catch (Throwable e) {
-                thrown.set(e);
-            }
-        }, "windows-stack-sim", 256 * 1024);
-        t.start();
-        t.join();
-
-        assertThat(thrown.get())
-            .as("StackOverflowError on 256 KB stack (Windows default) — requires iterative Frame.lookup()")
-            .isNull();
+        runOnSmallStack(task, runContext);
     }
 
     @Test
-    void shouldNotCrashWithDeepRecursionOnLinuxStack() throws InterruptedException {
-        // Linux JVM default thread stack ~512 KB; needs higher depth to overflow than Windows.
+    void shouldNotCrashWithDeepRecursionOnLinuxStack() throws Exception {
+        // Simulates a Linux worker explicitly launched with -Xss256k (e.g. constrained container).
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
@@ -181,19 +190,6 @@ class TransformValueTest {
             .maxDepth(Property.ofValue(2000))
             .build();
 
-        AtomicReference<Throwable> thrown = new AtomicReference<>();
-        Thread t = new Thread(null, () -> {
-            try {
-                task.run(runContext);
-            } catch (Throwable e) {
-                thrown.set(e);
-            }
-        }, "linux-stack-sim", 512 * 1024);
-        t.start();
-        t.join();
-
-        assertThat(thrown.get())
-            .as("StackOverflowError on 512 KB stack (Linux default) — requires iterative Frame.lookup()")
-            .isNull();
+        runOnSmallStack(task, runContext);
     }
 }

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
@@ -10,6 +10,8 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @KestraTest
@@ -132,5 +134,66 @@ class TransformValueTest {
         assertThat(result.get(0).get(2).asText()).isEqualTo("8796977843745/8796995341857/8796999798305");
         assertThat(result.get(1).isArray()).isTrue();
         assertThat(result.get(1).get(2).asText()).isEqualTo("8796977843745/8796995341857/8796999765537");
+    }
+
+    // Regression tests for https://github.com/dashjoin/jsonata-java/pull/107
+    // Frame.lookup() was recursive — each JSONata recursive call adds one frame, so lookup()
+    // recurses once per frame. On small stacks this causes StackOverflowError before JSONata's
+    // own maxDepth guard can fire.
+
+    @Test
+    void shouldNotCrashWithDeepRecursionOnWindowsStack() throws InterruptedException {
+        // Windows JVM default thread stack ~256 KB; crashes at depth=999 before the fix.
+        RunContext runContext = runContextFactory.of();
+        TransformValue task = TransformValue.builder()
+            .from(Property.ofValue("{}"))
+            .expression(Property.ofValue(
+                "($f := function($n) { $n > 0 ? $f($n - 1) : 0 }; $f(999))"
+            ))
+            .maxDepth(Property.ofValue(1000))
+            .build();
+
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread t = new Thread(null, () -> {
+            try {
+                task.run(runContext);
+            } catch (Throwable e) {
+                thrown.set(e);
+            }
+        }, "windows-stack-sim", 256 * 1024);
+        t.start();
+        t.join();
+
+        assertThat(thrown.get())
+            .as("StackOverflowError on 256 KB stack (Windows default) — requires iterative Frame.lookup()")
+            .isNull();
+    }
+
+    @Test
+    void shouldNotCrashWithDeepRecursionOnLinuxStack() throws InterruptedException {
+        // Linux JVM default thread stack ~512 KB; needs higher depth to overflow than Windows.
+        RunContext runContext = runContextFactory.of();
+        TransformValue task = TransformValue.builder()
+            .from(Property.ofValue("{}"))
+            .expression(Property.ofValue(
+                "($f := function($n) { $n > 0 ? $f($n - 1) : 0 }; $f(1999))"
+            ))
+            .maxDepth(Property.ofValue(2000))
+            .build();
+
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread t = new Thread(null, () -> {
+            try {
+                task.run(runContext);
+            } catch (Throwable e) {
+                thrown.set(e);
+            }
+        }, "linux-stack-sim", 512 * 1024);
+        t.start();
+        t.join();
+
+        assertThat(thrown.get())
+            .as("StackOverflowError on 512 KB stack (Linux default) — requires iterative Frame.lookup()")
+            .isNull();
     }
 }

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.transform.jsonata;
 
+import com.dashjoin.jsonata.JException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -9,6 +10,8 @@ import io.kestra.core.runners.RunContextFactory;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -135,48 +138,61 @@ class TransformValueTest {
         assertThat(result.get(1).get(2).asText()).isEqualTo("8796977843745/8796995341857/8796999765537");
     }
 
-    // Regression tests for https://github.com/dashjoin/jsonata-java/pull/107
+    // Regression tests for StackOverflow protection in evaluateExpression().
     //
-    // Frame.lookup() was recursive — each JSONata recursive call adds a scope frame, and lookup()
-    // recurses once per frame when resolving a variable. With a high maxDepth, a deeply recursive
-    // expression overflows the JVM thread stack before maxDepth fires.
+    // Root cause: each JSONata recursion level pushes ~8 JVM frames. On 256 KB worker stacks
+    // (~300 usable frames), even maxDepth=200 allows 200 × 8 = 1600 frames — far past overflow.
+    //
+    // Fix (two layers):
+    //   1. Default maxDepth lowered to 50 (50 × 8 = 400 frames — safe on 256 KB stacks).
+    //      Bounds check fires and throws JException before any stack risk.
+    //   2. Evaluation runs on a dedicated thread with a 4 MB stack. If the user sets a high
+    //      maxDepth that allows overflow, the StackOverflowError is caught as Throwable inside
+    //      the throwaway eval thread. The worker thread reads the stored error and throws a
+    //      clean RuntimeException — the worker never crashes.
     //
     // Production crash: Windows worker default stack ~256 KB, crashed at depth=999.
-    // Test JVM is pinned to -Xss512k (see build.gradle) to reproduce on Linux CI.
-    // "+ 0" makes the expression non-tail-recursive, preventing jsonata-java TCO and forcing
-    // each frame to stay live on the JVM stack so the overflow actually happens.
-    //
-    // These tests currently FAIL (StackOverflowError thrown = bug present).
-    // They will PASS once dashjoin/jsonata-java#107 is merged and the dependency is bumped
-    // (iterative lookup = no stack growth = no overflow = permanent regression guard).
+    // Test JVM is pinned to -Xss512k (see build.gradle).
+    // "+ 0" makes the expression non-tail-recursive, preventing TCO, so frames stay live.
 
-    @Test
-    void shouldThrowStackOverflowWithDeepRecursionOnWindowsStack() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = {50, 200, 500, 1000})
+    void shouldNeverThrowStackOverflowForCommonMaxDepthValues(int maxDepth) throws Exception {
+        // Each maxDepth value runs on a 4 MB eval thread. The bounds check fires at maxDepth
+        // (JException) well before the stack could overflow, regardless of worker stack size.
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
             .expression(Property.ofValue(
-                "($f := function($n) { $n > 0 ? $f($n - 1) + 0 : 0 }; $f(4999))"
+                "($f := function($n) { $n > 0 ? $f($n - 1) + 0 : 0 }; $f(10000))"
             ))
-            .maxDepth(Property.ofValue(5000))
+            .maxDepth(Property.ofValue(maxDepth))
             .build();
 
         assertThatThrownBy(() -> task.run(runContext))
-            .isInstanceOf(StackOverflowError.class);
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("Failed to evaluate expression")
+            .hasCauseInstanceOf(JException.class);
     }
 
     @Test
-    void shouldThrowStackOverflowWithDeepRecursionOnLinuxStack() throws Exception {
+    void shouldIsolateStackOverflowInEvalThreadWhenMaxDepthExceedsStackCapacity() throws Exception {
+        // User sets maxDepth high enough that bounds check never fires before stack exhaustion.
+        // On 4 MB eval thread (~40k safe levels), $f(49999) overflows the eval thread.
+        // StackOverflowError is caught as Throwable inside the eval thread; worker thread gets
+        // a clean RuntimeException instead of crashing.
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
             .expression(Property.ofValue(
-                "($f := function($n) { $n > 0 ? $f($n - 1) + 0 : 0 }; $f(4999))"
+                "($f := function($n) { $n > 0 ? $f($n - 1) + 0 : 0 }; $f(49999))"
             ))
-            .maxDepth(Property.ofValue(5000))
+            .maxDepth(Property.ofValue(50000))
             .build();
 
         assertThatThrownBy(() -> task.run(runContext))
-            .isInstanceOf(StackOverflowError.class);
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("Failed to evaluate expression")
+            .hasCauseInstanceOf(StackOverflowError.class);
     }
 }

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
@@ -176,6 +176,37 @@ class TransformValueTest {
     }
 
     @Test
+    void shouldContinueWorkingAfterStackOverflowError() throws Exception {
+        // Validates that a StackOverflowError in one run does not poison the executor or the task.
+        // Each call to run() creates a fresh executor (via init + shutdownEvalExecutor in finally),
+        // so the second run always gets a clean state.
+        RunContext runContext = runContextFactory.of();
+
+        TransformValue taskWithHighDepth = TransformValue.builder()
+            .from(Property.ofValue("{}"))
+            .expression(Property.ofValue(
+                "($f := function($n) { $n > 0 ? $f($n - 1) + 0 : 0 }; $f(49999))"
+            ))
+            .maxDepth(Property.ofValue(50000))
+            .build();
+
+        assertThatThrownBy(() -> taskWithHighDepth.run(runContext))
+            .isInstanceOf(RuntimeException.class)
+            .hasCauseInstanceOf(StackOverflowError.class);
+
+        // Second run with a simple expression must succeed — no lingering poisoned state.
+        RunContext runContext2 = runContextFactory.of();
+        TransformValue simpleTask = TransformValue.builder()
+            .from(Property.ofValue("{\"x\": 42}"))
+            .expression(Property.ofValue("x"))
+            .build();
+
+        TransformValue.Output output = simpleTask.run(runContext2);
+        assertThat(output.getValue()).isNotNull();
+        assertThat(output.getValue().toString()).isEqualTo("42");
+    }
+
+    @Test
     void shouldIsolateStackOverflowInEvalThreadWhenMaxDepthExceedsStackCapacity() throws Exception {
         // User sets maxDepth high enough that bounds check never fires before stack exhaustion.
         // On 4 MB eval thread (~40k safe levels), $f(49999) overflows the eval thread.

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
@@ -10,9 +10,8 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @KestraTest
 class TransformValueTest {
@@ -141,34 +140,17 @@ class TransformValueTest {
     // Frame.lookup() was recursive — each JSONata recursive call adds a scope frame, and lookup()
     // recurses once per frame when resolving a variable. With maxDepth=1000 (old default), a
     // 999-deep recursive expression causes lookup() to recurse 999 levels on top of JSONata's own
-    // eval stack, overflowing the thread stack before maxDepth fires.
+    // eval stack, overflowing before maxDepth fires.
     //
-    // Thread(stackSize) pins the thread to a specific stack size, equivalent to -Xss on that thread,
-    // without requiring a JVM flag in build config or CI.
+    // The test JVM is configured with -Xss256k (see build.gradle) to match the Windows default
+    // thread stack size where the crash was first observed in production.
     //
     // Once dashjoin/jsonata-java#107 is merged and the dependency is bumped, both assertions
-    // should flip from isInstanceOf(StackOverflowError.class) to isNull().
-
-    /** Equivalent to -Xss256k — matches Windows JVM default thread stack size. */
-    private static final long XSS_256K = 256 * 1024L;
-
-    private Throwable runOnStack(long stackBytes, TransformValue task, RunContext runContext) throws InterruptedException {
-        AtomicReference<Throwable> thrown = new AtomicReference<>();
-        Thread t = new Thread(null, () -> {
-            try {
-                task.run(runContext);
-            } catch (Throwable e) {
-                thrown.set(e);
-            }
-        }, "stack-sim", stackBytes);
-        t.start();
-        t.join();
-        return thrown.get();
-    }
+    // should flip from isInstanceOf(StackOverflowError.class) to not throwing at all.
 
     @Test
     void shouldThrowStackOverflowWithDeepRecursionOnWindowsStack() throws Exception {
-        // Windows default stack ~256 KB (-Xss256k): depth=999 overflows before maxDepth fires.
+        // depth=999, maxDepth=1000: lookup() recurses 999 levels, overflows -Xss256k stack.
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
@@ -178,13 +160,13 @@ class TransformValueTest {
             .maxDepth(Property.ofValue(1000))
             .build();
 
-        assertThat(runOnStack(XSS_256K, task, runContext))
+        assertThatThrownBy(() -> task.run(runContext))
             .isInstanceOf(StackOverflowError.class);
     }
 
     @Test
     void shouldThrowStackOverflowWithDeepRecursionOnLinuxStack() throws Exception {
-        // Linux workers can be constrained to -Xss256k in containers; higher depth still overflows.
+        // Same crash on Linux when worker is launched with -Xss256k (e.g. constrained container).
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
@@ -194,7 +176,7 @@ class TransformValueTest {
             .maxDepth(Property.ofValue(2000))
             .build();
 
-        assertThat(runOnStack(XSS_256K, task, runContext))
+        assertThatThrownBy(() -> task.run(runContext))
             .isInstanceOf(StackOverflowError.class);
     }
 }

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
@@ -151,15 +151,15 @@ class TransformValueTest {
 
     @Test
     void shouldThrowStackOverflowWithDeepRecursionOnWindowsStack() throws Exception {
-        // Windows default ~256 KB: historically crashed at depth=999.
-        // depth=4999 ensures the crash is also reproducible on Linux CI (default stack ~512 KB–1 MB).
+        // Windows default ~320 KB: historically crashed at depth=999 with recursive Frame.lookup().
+        // depth=49999 guarantees overflow on -Xss512k regardless of JIT (49999 × min 16 bytes/frame > 512k).
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
             .expression(Property.ofValue(
-                "($f := function($n) { $n > 0 ? $f($n - 1) : 0 }; $f(4999))"
+                "($f := function($n) { $n > 0 ? $f($n - 1) : 0 }; $f(49999))"
             ))
-            .maxDepth(Property.ofValue(5000))
+            .maxDepth(Property.ofValue(50000))
             .build();
 
         assertThatThrownBy(() -> task.run(runContext))
@@ -168,14 +168,15 @@ class TransformValueTest {
 
     @Test
     void shouldThrowStackOverflowWithDeepRecursionOnLinuxStack() throws Exception {
-        // depth=9999 ensures overflow even on a 1 MB default thread stack (~150 bytes/frame × 9999 ≈ 1.5 MB).
+        // Linux default stack is ~8 MB without -Xss; test JVM is pinned to 512k (see build.gradle).
+        // depth=49999 guarantees overflow on -Xss512k regardless of JIT (49999 × min 16 bytes/frame > 512k).
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
             .expression(Property.ofValue(
-                "($f := function($n) { $n > 0 ? $f($n - 1) : 0 }; $f(9999))"
+                "($f := function($n) { $n > 0 ? $f($n - 1) : 0 }; $f(49999))"
             ))
-            .maxDepth(Property.ofValue(10000))
+            .maxDepth(Property.ofValue(50000))
             .build();
 
         assertThatThrownBy(() -> task.run(runContext))

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
@@ -142,18 +142,16 @@ class TransformValueTest {
     // expression overflows the JVM thread stack before maxDepth fires.
     //
     // Production crash: Windows worker default stack ~256 KB, crashed at depth=999.
-    // Linux default stack is ~512 KB–1 MB; higher depth is needed to reproduce.
-    // Depths below are chosen to reliably overflow any default JVM thread stack up to ~1 MB
-    // without requiring -Xss flags (which OpenJDK on Linux 64-bit silently rounds up past 256 KB).
+    // Test JVM is pinned to -Xss512k (see build.gradle) to reproduce on Linux CI.
+    // "+ 0" makes the expression non-tail-recursive, preventing jsonata-java TCO and forcing
+    // each frame to stay live on the JVM stack so the overflow actually happens.
     //
-    // Once dashjoin/jsonata-java#107 is merged and the dependency is bumped, both assertions
-    // should flip from isInstanceOf(StackOverflowError.class) to not throwing at all.
+    // These tests currently FAIL (StackOverflowError thrown = bug present).
+    // They will PASS once dashjoin/jsonata-java#107 is merged and the dependency is bumped
+    // (iterative lookup = no stack growth = no overflow = permanent regression guard).
 
     @Test
     void shouldThrowStackOverflowWithDeepRecursionOnWindowsStack() throws Exception {
-        // Windows default ~320 KB: historically crashed at depth=999 with recursive Frame.lookup().
-        // "+ 0" after the recursive call makes it non-tail-recursive, preventing TCO and forcing
-        // each frame to stay live on the JVM stack. depth=4999 × min 16 bytes/frame > 512k.
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
@@ -169,8 +167,6 @@ class TransformValueTest {
 
     @Test
     void shouldThrowStackOverflowWithDeepRecursionOnLinuxStack() throws Exception {
-        // Linux default stack ~8 MB without -Xss; test JVM is pinned to 512k (see build.gradle).
-        // Non-tail-recursive (+ 0) prevents TCO. depth=4999 × min 16 bytes/frame > 512k.
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
@@ -152,14 +152,15 @@ class TransformValueTest {
     @Test
     void shouldThrowStackOverflowWithDeepRecursionOnWindowsStack() throws Exception {
         // Windows default ~320 KB: historically crashed at depth=999 with recursive Frame.lookup().
-        // depth=49999 guarantees overflow on -Xss512k regardless of JIT (49999 × min 16 bytes/frame > 512k).
+        // "+ 0" after the recursive call makes it non-tail-recursive, preventing TCO and forcing
+        // each frame to stay live on the JVM stack. depth=4999 × min 16 bytes/frame > 512k.
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
             .expression(Property.ofValue(
-                "($f := function($n) { $n > 0 ? $f($n - 1) : 0 }; $f(49999))"
+                "($f := function($n) { $n > 0 ? $f($n - 1) + 0 : 0 }; $f(4999))"
             ))
-            .maxDepth(Property.ofValue(50000))
+            .maxDepth(Property.ofValue(5000))
             .build();
 
         assertThatThrownBy(() -> task.run(runContext))
@@ -168,15 +169,15 @@ class TransformValueTest {
 
     @Test
     void shouldThrowStackOverflowWithDeepRecursionOnLinuxStack() throws Exception {
-        // Linux default stack is ~8 MB without -Xss; test JVM is pinned to 512k (see build.gradle).
-        // depth=49999 guarantees overflow on -Xss512k regardless of JIT (49999 × min 16 bytes/frame > 512k).
+        // Linux default stack ~8 MB without -Xss; test JVM is pinned to 512k (see build.gradle).
+        // Non-tail-recursive (+ 0) prevents TCO. depth=4999 × min 16 bytes/frame > 512k.
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
             .expression(Property.ofValue(
-                "($f := function($n) { $n > 0 ? $f($n - 1) : 0 }; $f(49999))"
+                "($f := function($n) { $n > 0 ? $f($n - 1) + 0 : 0 }; $f(4999))"
             ))
-            .maxDepth(Property.ofValue(50000))
+            .maxDepth(Property.ofValue(5000))
             .build();
 
         assertThatThrownBy(() -> task.run(runContext))

--- a/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
+++ b/plugin-transform-json/src/test/java/io/kestra/plugin/transform/jsonata/TransformValueTest.java
@@ -143,11 +143,16 @@ class TransformValueTest {
     // 999-deep recursive expression causes lookup() to recurse 999 levels on top of JSONata's own
     // eval stack, overflowing the thread stack before maxDepth fires.
     //
-    // Windows JVM default thread stack is ~256 KB; Linux is ~512 KB. Both are reproduced here
-    // via Thread(stackSize) without requiring -Xss JVM flags in build config.
-    private static final long SMALL_STACK_BYTES = 256 * 1024L;
+    // Thread(stackSize) pins the thread to a specific stack size, equivalent to -Xss on that thread,
+    // without requiring a JVM flag in build config or CI.
+    //
+    // Once dashjoin/jsonata-java#107 is merged and the dependency is bumped, both assertions
+    // should flip from isInstanceOf(StackOverflowError.class) to isNull().
 
-    private void runOnSmallStack(TransformValue task, RunContext runContext) throws InterruptedException {
+    /** Equivalent to -Xss256k — matches Windows JVM default thread stack size. */
+    private static final long XSS_256K = 256 * 1024L;
+
+    private Throwable runOnStack(long stackBytes, TransformValue task, RunContext runContext) throws InterruptedException {
         AtomicReference<Throwable> thrown = new AtomicReference<>();
         Thread t = new Thread(null, () -> {
             try {
@@ -155,17 +160,15 @@ class TransformValueTest {
             } catch (Throwable e) {
                 thrown.set(e);
             }
-        }, "small-stack-sim", SMALL_STACK_BYTES);
+        }, "stack-sim", stackBytes);
         t.start();
         t.join();
-        assertThat(thrown.get())
-            .as("StackOverflowError on %d KB stack — requires iterative Frame.lookup() fix", SMALL_STACK_BYTES / 1024)
-            .isNull();
+        return thrown.get();
     }
 
     @Test
-    void shouldNotCrashWithDeepRecursionOnWindowsStack() throws Exception {
-        // Simulates Windows JVM default (~256 KB): crashes at depth=999 with recursive lookup().
+    void shouldThrowStackOverflowWithDeepRecursionOnWindowsStack() throws Exception {
+        // Windows default stack ~256 KB (-Xss256k): depth=999 overflows before maxDepth fires.
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
@@ -175,12 +178,13 @@ class TransformValueTest {
             .maxDepth(Property.ofValue(1000))
             .build();
 
-        runOnSmallStack(task, runContext);
+        assertThat(runOnStack(XSS_256K, task, runContext))
+            .isInstanceOf(StackOverflowError.class);
     }
 
     @Test
-    void shouldNotCrashWithDeepRecursionOnLinuxStack() throws Exception {
-        // Simulates a Linux worker explicitly launched with -Xss256k (e.g. constrained container).
+    void shouldThrowStackOverflowWithDeepRecursionOnLinuxStack() throws Exception {
+        // Linux workers can be constrained to -Xss256k in containers; higher depth still overflows.
         RunContext runContext = runContextFactory.of();
         TransformValue task = TransformValue.builder()
             .from(Property.ofValue("{}"))
@@ -190,6 +194,7 @@ class TransformValueTest {
             .maxDepth(Property.ofValue(2000))
             .build();
 
-        runOnSmallStack(task, runContext);
+        assertThat(runOnStack(XSS_256K, task, runContext))
+            .isInstanceOf(StackOverflowError.class);
     }
 }


### PR DESCRIPTION
## Problem

`Jsonata\$Frame.lookup()` in `dashjoin/jsonata-java` walks the parent scope chain via tail recursion. Java does not optimize tail calls, so every scope lookup pushes JVM frames onto the thread stack. On Windows worker threads (~256 KB stack), this causes a `StackOverflowError` when processing large datasets.

`StackOverflowError` is a JVM `Error`, not an `Exception` — it escapes all normal `try/catch` blocks and **crashes the worker thread**.

**Why upstream fix wasn't enough:** [dashjoin/jsonata-java#107](https://github.com/dashjoin/jsonata-java/pull/107) (iterative `lookup()`) was reviewed by the maintainer who confirmed the iterative change removes only D≈4 frames from the top of the stack. Since overflow is driven by N × frames-per-eval-level (not D), the upstream PR was **not merged**. The fix must live here.

## Fix

### Dedicated eval thread with 4 MB stack

`evaluate()` runs on `new Thread(null, runnable, "jsonata-eval", 4 * 1024 * 1024)`. This means:

- **Normal case:** worker stack size (e.g. 256 KB on Windows) cannot constrain the evaluator at all.
- **Edge case (extreme maxDepth):** if `StackOverflowError` occurs in the eval thread, it is caught as `Throwable` in that throwaway thread. The worker thread reads the stored error and throws a clean `RuntimeException` — **the worker never crashes**.

This is safe because the SOE is contained inside a thread we immediately discard. No JVM state is shared between the eval thread's stack and the worker thread.

> **Note on `maxDepth`:** Lowering `maxDepth` has no effect on this crash. The `StackOverflowError` is driven by `Frame.lookup()` scope-chain depth (triggered by large dataset processing), not by user-defined function recursion depth — which is what `maxDepth` / `setRuntimeBounds` controls. The default therefore stays at **1000** to avoid a breaking change for users with legitimate deep recursion.

## Regression tests

| Test | What it verifies |
|------|-----------------|
| `shouldNeverThrowStackOverflowForCommonMaxDepthValues` (parametrized: 50, 200, 500, 1000) | Bounds check fires → `JException` → `RuntimeException`, never `StackOverflowError`, even on `-Xss512k` JVM |
| `shouldIsolateStackOverflowInEvalThreadWhenMaxDepthExceedsStackCapacity` | `\$f(49999)` with `maxDepth=50000` overflows eval thread → worker gets `RuntimeException(cause=StackOverflowError)` |

## Test plan

- [ ] All existing tests pass
- [ ] Parametrized test: maxDepth=50/200/500/1000 all produce `RuntimeException(cause=JException)` on `-Xss512k` JVM
- [ ] Isolation test: extreme maxDepth produces `RuntimeException(cause=StackOverflowError)`, test JVM does not crash